### PR TITLE
Fixed typo in reflow docs

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1744,7 +1744,7 @@ class Chart {
 
     /**
      * Reflows the chart to its container. By default, the Resize Observer is
-     * attached to the chart's div which allows to reflows the he chart
+     * attached to the chart's div which allows to reflows the chart
      * automatically to its container, as per the
      * [chart.reflow](https://api.highcharts.com/highcharts/chart.reflow)
      * option.


### PR DESCRIPTION
I fixed a typo in the documentation of Chart.reflow.
This is my first time contributing to this repository, so please let me know if I am doing something wrong.